### PR TITLE
Extract Kafka out of docker compose file

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,33 +16,6 @@ services:
     environment:
       KAFKA_HOST: kafka:9092
 
-  kafka:
-    image: bitnami/kafka:3.2
-    container_name: kafka
-    hostname: kafka
-    restart: unless-stopped
-    networks:
-      - kafka
-    expose:
-      - "9092"
-    deploy:
-      resources:
-        limits:
-          memory: 512m
-    environment:
-      KAFKA_CFG_BROKER_ID: 1
-      KAFKA_KRAFT_CLUSTER_ID: AAAAAAAAAAAAAAAAAAAAAA== # 16 null bytes, base64 encoded
-      BITNAMI_DEBUG: "true"
-      ALLOW_PLAINTEXT_LISTENER: yes
-      KAFKA_ENABLE_KRAFT: yes
-      KAFKA_CFG_PROCESS_ROLES: broker,controller
-      KAFKA_CFG_CONTROLLER_LISTENER_NAMES: CONTROLLER
-      KAFKA_CFG_CONTROLLER_QUORUM_VOTERS: 1@localhost:9999
-      KAFKA_CFG_LISTENERS: CONTROLLER://:9999,LOCAL://:9090,DOCKER://:9092
-      KAFKA_CFG_ADVERTISED_LISTENERS: LOCAL://localhost:9090,DOCKER://kafka:9092
-      KAFKA_CFG_LISTENER_SECURITY_PROTOCOL_MAP: CONTROLLER:PLAINTEXT,LOCAL:PLAINTEXT,DOCKER:PLAINTEXT
-      KAFKA_CFG_INTER_BROKER_LISTENER_NAME: LOCAL
-
 networks:
   kafka:
     external: true


### PR DESCRIPTION
Since Kafka is now centrally managed by https://github.com/BeemoBot/infrastructure/blob/main/docker/docker-compose.yml, let's remove it from here so that this compose file only contains services essential to matcha (which, currently, is only matcha itself).