### PR TITLE
Send ratelimit responses without blocking

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,17 +5,9 @@ services:
     build: .
     container_name: matcha
     restart: unless-stopped
-    networks:
-      - kafka
-    depends_on:
-      - kafka
     deploy:
       resources:
         limits:
           memory: 256m
-    environment:
-      KAFKA_HOST: kafka:9092
-
-networks:
-  kafka:
-    external: true
+    env_file:
+      - .env

--- a/src/main/java/dev/ayu/matcha/KafkaRatelimitClient.kt
+++ b/src/main/java/dev/ayu/matcha/KafkaRatelimitClient.kt
@@ -49,14 +49,14 @@ class RatelimitClient(conn: KafkaConnection) : KafkaClient<RatelimitClientData>(
         log.debug("Incoming '$type' quota request from client '$client' in cluster $sourceCluster")
         ratelimitProvider.getClientRatelimit(client).requestQuota()
         log.debug("Granted '$type' quota request for client '$client' in cluster $sourceCluster")
-        msg.respond(null)
+        msg.respond(null, false)
     }
 
 }
 
 private class RatelimitProvider(private val burst: Int, private val duration: Duration) {
 
-    private val limiters = ConcurrentHashMap<String, SuspendingRatelimit>();
+    private val limiters = ConcurrentHashMap<String, SuspendingRatelimit>()
 
     fun getClientRatelimit(client: String): SuspendingRatelimit = limiters.computeIfAbsent(client) {
         SuspendingRatelimit(burst, duration)


### PR DESCRIPTION
Previously, Kafka's `send` method may sometimes block for long preiods of time while re-establishing a connection. Based on https://github.com/BeemoBot/latte/pull/7, we now have the ability to disable that behavior, since we definitely don't want to block in fast-paced ratelimit handling - either the reply gets sent quickly, or it doesn't get sent at all, at which point requesting clients will use their own internal timer to calculate fallback ratelimits.

There was also some leftover stuff in the dockerfile I've cleaned up, cause who doesn't love cross-pollution of pull requests.