### PR TITLE
Use clientId from Kafka headers instead of payload

### DIFF
--- a/src/main/java/dev/ayu/matcha/KafkaRatelimitClient.kt
+++ b/src/main/java/dev/ayu/matcha/KafkaRatelimitClient.kt
@@ -39,8 +39,8 @@ class RatelimitClient(conn: KafkaConnection) : KafkaClient<RatelimitClientData>(
         type: String,
     ) {
         val sourceCluster = msg.headers.sourceCluster
+        val client = msg.headers.clientId
         val expiresAt = msg.value?.requestExpiresAt
-        val client = msg.value?.client ?: "fallback"
         if (expiresAt != null && (expiresAt + EXPIRY_GRACE_PERIOD) < System.currentTimeMillis()) {
             log.info("Incoming expired '$type' quota request from client '$client' in cluster $sourceCluster, ignoring")
             // If the request has already expired, ignore it to not eat quotas unnecessarily


### PR DESCRIPTION
Following the updates of https://github.com/BeemoBot/latte/pull/8, we can now access the clientId from the headers and don't have to manually provide and access it on the request payload anymore.

Marking this as draft until https://github.com/BeemoBot/latte/pull/8 is merged.